### PR TITLE
Add Angular translation pipe support and HTML integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-04-20
+
+### Added
+- **Angular translate pipe completion** — auto-completes translation keys in HTML templates when typing inside a string followed by `| translate` (or your configured pipe name); uses substring matching so partial key fragments work across group and key parts
+- **HTML file support for "Edit Label"** — right-click on a translation key in any `.html` / `.htm` file (Angular `'key' | translate` syntax) to edit the label directly from the editor, identical to the existing Blade integration
+- **Configurable translate pipe name** — the Angular pipe name used for completion and editor integration is now configurable in Settings (default: `translate`)
+
+### Fixed
+- **Capitalisation in auto-translation** — OpenAI now only capitalises the very first character of a translation instead of applying Title Case to every word
+
 ## [2.1.0] - 2026-04-03
 
 ### Added

--- a/src/main/kotlin/org/label/translate/labeltranslate/AngularTranslateCompletionContributor.kt
+++ b/src/main/kotlin/org/label/translate/labeltranslate/AngularTranslateCompletionContributor.kt
@@ -1,0 +1,114 @@
+package org.label.translate.labeltranslate
+
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.IconLoader
+import com.intellij.openapi.util.TextRange
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.util.ProcessingContext
+
+private val PLUGIN_ICON by lazy {
+    IconLoader.getIcon("/icons/pluginIcon.svg", AngularTranslateCompletionContributor::class.java)
+}
+
+class AngularTranslateCompletionContributor : CompletionContributor() {
+    init {
+        extend(CompletionType.BASIC, PlatformPatterns.psiElement(), TranslateCompletionProvider())
+    }
+}
+
+private class TranslateCompletionProvider : CompletionProvider<CompletionParameters>() {
+
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        // Use the editor's virtual file so this works even inside injected language fragments
+        val virtualFile = parameters.editor.virtualFile ?: return
+        val ext = virtualFile.extension?.toLowerCase() ?: return
+        if (ext != "html" && ext != "htm") return
+
+        val document = parameters.editor.document
+        val project = parameters.position.project
+
+        // Build the pipe regex from the configured pipe name
+        val pipeName = Regex.escape(TranslatePipeConfig().pipeName)
+        val translatePipe = Regex("""\|\s*$pipeName\b""", RegexOption.IGNORE_CASE)
+
+        // parameters.offset may be an offset inside an injected fragment (e.g. {{ }} or [attr]="").
+        // Convert it to the host document offset so line/text lookups are correct.
+        val hostOffset = InjectedLanguageManager.getInstance(project)
+            .injectedToHost(parameters.position, parameters.offset)
+
+        val lineNum = document.getLineNumber(hostOffset)
+        val lineStart = document.getLineStartOffset(lineNum)
+        val lineEnd = document.getLineEndOffset(lineNum)
+
+        val textBefore = document.getText(TextRange(lineStart, hostOffset))
+        val textAfter = document.getText(TextRange(hostOffset, lineEnd))
+            .replace(CompletionUtil.DUMMY_IDENTIFIER_TRIMMED, "")
+
+        // Only provide completions when the configured pipe follows the cursor on this line
+        if (!translatePipe.containsMatchIn(textAfter)) return
+
+        // Find the opening quote immediately before the typed prefix
+        val quotePos = textBefore.lastIndexOfAny(charArrayOf('\'', '"'))
+        if (quotePos < 0) return
+
+        // Ensure cursor is still inside the string (no closing quote between open and cursor)
+        val quoteChar = textBefore[quotePos]
+        val insideText = textBefore.substring(quotePos + 1)
+        if (insideText.contains(quoteChar)) return
+
+        val typedPrefix = insideText
+        val allKeys = loadAllTranslationKeys(project)
+
+        val customResult = result.withPrefixMatcher(SubstringPrefixMatcher(typedPrefix))
+        for (key in allKeys) {
+            customResult.addElement(
+                LookupElementBuilder.create(key)
+                    .withTypeText("Translation key")
+                    .withIcon(PLUGIN_ICON)
+                    .bold()
+            )
+        }
+    }
+
+    private fun loadAllTranslationKeys(project: Project): List<String> {
+        val keys = mutableListOf<String>()
+        for (resourcePath in TranslationSet.getResourcePaths()) {
+            val sets = TranslationSet.loadFromPath(project.basePath, resourcePath)
+            for (set in sets) {
+                val group = set.displayName.toLowerCase()
+                for (key in set.getKeys()) {
+                    keys.add("$group.$key")
+                }
+            }
+        }
+        return keys.sorted()
+    }
+}
+
+private class SubstringPrefixMatcher(prefix: String) : PrefixMatcher(prefix) {
+    override fun prefixMatches(name: String): Boolean {
+        if (prefix.isEmpty()) return true
+        val lastDot = prefix.lastIndexOf('.')
+        if (lastDot < 0) return name.contains(prefix, ignoreCase = true)
+
+        // e.g. prefix = "labels.descr" → groupPart = "labels", keyFragment = "descr"
+        val groupPart = prefix.substring(0, lastDot)
+        val keyFragment = prefix.substring(lastDot + 1)
+
+        // Group must match exactly
+        if (!name.startsWith("$groupPart.", ignoreCase = true)) return false
+
+        // The key part (everything after "labels.") must contain the fragment
+        val keyPart = name.substring(groupPart.length + 1)
+        return keyFragment.isEmpty() || keyPart.contains(keyFragment, ignoreCase = true)
+    }
+
+    override fun cloneWithPrefix(prefix: String) = SubstringPrefixMatcher(prefix)
+}

--- a/src/main/kotlin/org/label/translate/labeltranslate/EditLabelAction.kt
+++ b/src/main/kotlin/org/label/translate/labeltranslate/EditLabelAction.kt
@@ -13,7 +13,13 @@ class EditLabelAction : AnAction("Edit Label") {
 
     companion object {
         // Matches __('key'), __("key"), trans('key'), trans("key"), @lang('key'), @lang("key")
-        private val TRANSLATION_REGEX = Regex("""(?:__\s*\(\s*|trans\s*\(\s*|@lang\s*\(\s*)['"]([^'"]+)['"]""")
+        private val BLADE_TRANSLATION_REGEX = Regex("""(?:__\s*\(\s*|trans\s*\(\s*|@lang\s*\(\s*)['"]([^'"]+)['"]""")
+
+        // Matches 'key' | <pipe> and "key" | <pipe>, using the pipe name from settings
+        private fun angularTranslateRegex(): Regex {
+            val pipe = Regex.escape(TranslatePipeConfig().pipeName)
+            return Regex("""['"]([^'"]+)['"]\s*\|\s*$pipe\b""", RegexOption.IGNORE_CASE)
+        }
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
@@ -22,9 +28,11 @@ class EditLabelAction : AnAction("Edit Label") {
         val editor = e.getData(CommonDataKeys.EDITOR)
         val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE)
 
-        val isBladeFile = virtualFile?.name?.endsWith(".blade.php") == true
+        val isSupportedFile = virtualFile?.name?.endsWith(".blade.php") == true
+            || virtualFile?.extension?.toLowerCase() == "html"
+            || virtualFile?.extension?.toLowerCase() == "htm"
 
-        if (!isBladeFile || editor == null) {
+        if (!isSupportedFile || editor == null) {
             e.presentation.isEnabledAndVisible = false
             return
         }
@@ -70,9 +78,11 @@ class EditLabelAction : AnAction("Edit Label") {
 
         val cursorColumn = caretOffset - lineStart
 
-        for (match in TRANSLATION_REGEX.findAll(lineText)) {
-            if (cursorColumn >= match.range.first && cursorColumn <= match.range.last + 1) {
-                return match.groupValues[1]
+        for (regex in listOf(BLADE_TRANSLATION_REGEX, angularTranslateRegex())) {
+            for (match in regex.findAll(lineText)) {
+                if (cursorColumn >= match.range.first && cursorColumn <= match.range.last + 1) {
+                    return match.groupValues[1]
+                }
             }
         }
 

--- a/src/main/kotlin/org/label/translate/labeltranslate/LabelTranslateConfig.kt
+++ b/src/main/kotlin/org/label/translate/labeltranslate/LabelTranslateConfig.kt
@@ -62,3 +62,12 @@ class SeparatorConfig {
             properties.setValue("label_translate.separator", value)
         }
 }
+
+class TranslatePipeConfig {
+    private val properties = PropertiesComponent.getInstance()
+    var pipeName: String
+        get() = properties.getValue("label_translate.pipe_name", "translate")
+        set(value) {
+            properties.setValue("label_translate.pipe_name", value)
+        }
+}

--- a/src/main/kotlin/org/label/translate/labeltranslate/LabelTranslateSettingsConfigurable.kt
+++ b/src/main/kotlin/org/label/translate/labeltranslate/LabelTranslateSettingsConfigurable.kt
@@ -19,12 +19,15 @@ class LabelTranslateSettingsConfigurable : Configurable {
     private lateinit var removeFolderButton: JButton
     private lateinit var separatorField: JTextField
     private lateinit var separatorConfig: SeparatorConfig
+    private lateinit var pipeNameField: JTextField
+    private lateinit var pipeNameConfig: TranslatePipeConfig
 
     override fun createComponent(): JComponent {
         apiKeyConfig = ApiKeyConfig()
         defaultLanguage = DefaultLanguage()
         customFilePathConfig = CustomFilePathConfig()
         separatorConfig = SeparatorConfig()
+        pipeNameConfig = TranslatePipeConfig()
 
         val mainPanel = JPanel()
         mainPanel.layout = BoxLayout(mainPanel, BoxLayout.Y_AXIS)
@@ -37,6 +40,8 @@ class LabelTranslateSettingsConfigurable : Configurable {
         mainPanel.add(createLanguageDropdownSection())
         mainPanel.add(Box.createRigidArea(java.awt.Dimension(0, 20)))
         mainPanel.add(createSeparatorSection())
+        mainPanel.add(Box.createRigidArea(java.awt.Dimension(0, 20)))
+        mainPanel.add(createPipeNameSection())
         mainPanel.add(Box.createRigidArea(java.awt.Dimension(0, 20)))
         mainPanel.add(createCustomFolderSection())
 
@@ -110,6 +115,20 @@ class LabelTranslateSettingsConfigurable : Configurable {
         return separatorPanel
     }
 
+    private fun createPipeNameSection(): JPanel {
+        val pipePanel = JPanel()
+        pipePanel.layout = BoxLayout(pipePanel, BoxLayout.Y_AXIS)
+        pipePanel.add(JLabel("Angular Translate Pipe Name:"))
+
+        pipeNameField = JTextField(pipeNameConfig.pipeName, 20)
+        pipeNameField.minimumSize = java.awt.Dimension(400, 40)
+        pipeNameField.maximumSize = java.awt.Dimension(400, 40)
+        pipePanel.add(pipeNameField)
+
+        pipePanel.alignmentX = Component.LEFT_ALIGNMENT
+        return pipePanel
+    }
+
     private fun createCustomFolderSection(): JPanel {
         val folderPanel = JPanel()
         folderPanel.layout = BoxLayout(folderPanel, BoxLayout.Y_AXIS)
@@ -159,6 +178,7 @@ class LabelTranslateSettingsConfigurable : Configurable {
                 tokenField.text != apiKeyConfig.maxTokens ||
                 languageComboBox.selectedItem.toString().substringBefore(" -") != defaultLanguage.defaultLanguage ||
                 separatorField.text != separatorConfig.separator ||
+                pipeNameField.text != pipeNameConfig.pipeName ||
                 !customFilePathConfig.folderPaths.containsAll(folderListModel.elements().toList()) ||
                 !folderListModel.elements().toList().containsAll(customFilePathConfig.folderPaths)
     }
@@ -168,6 +188,7 @@ class LabelTranslateSettingsConfigurable : Configurable {
         apiKeyConfig.maxTokens = tokenField.text
         defaultLanguage.defaultLanguage = languageComboBox.selectedItem.toString().substringBefore(" -")
         separatorConfig.separator = separatorField.text.ifBlank { "->" }
+        pipeNameConfig.pipeName = pipeNameField.text.ifBlank { "translate" }
         customFilePathConfig.folderPaths = folderListModel.elements().toList()
 
         val bus = com.intellij.openapi.application.ApplicationManager.getApplication().messageBus
@@ -182,6 +203,7 @@ class LabelTranslateSettingsConfigurable : Configurable {
         languageComboBox.selectedItem = defaultOption
 
         separatorField.text = separatorConfig.separator
+        pipeNameField.text = pipeNameConfig.pipeName
         folderListModel.clear()
         customFilePathConfig.folderPaths.forEach { folderListModel.addElement(it) }
     }

--- a/src/main/kotlin/org/label/translate/labeltranslate/OpenAiService.kt
+++ b/src/main/kotlin/org/label/translate/labeltranslate/OpenAiService.kt
@@ -36,10 +36,9 @@ object OpenAiService {
 
         val startsWithCapital = wordToTranslate.firstOrNull()?.isUpperCase() == true
         val capitalizationInstruction = if (startsWithCapital)
-            "The original word starts with a capital letter, so all translations must also start with a capital letter. "
+            "Ensure ONLY the very first character of the translation is uppercase. Do not use Title Case for every word."
         else
-            "The original word starts with a lowercase letter, so all translations must also start with a lowercase letter. "
-
+            "Ensure the translation starts with a lowercase letter."
         val targetLanguages = langsUpper.filter { it != sourceLangUpper }
         val languagesJson = langsUpper.joinToString(", ") { "\\\"$it\\\": {\\\"$key\\\": \\\"translation\\\"}" }
         val jsonContent = """

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,10 @@
 
         <!-- Registering the settings configurable -->
         <projectConfigurable instance="org.label.translate.labeltranslate.LabelTranslateSettingsConfigurable" />
+
+        <!-- Angular | translate pipe completion in HTML templates -->
+        <completion.contributor language="any"
+            implementationClass="org.label.translate.labeltranslate.AngularTranslateCompletionContributor"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
- Introduced completion for Angular `| translate` pipe.
- Enabled "Edit Label" support in `.html`/`.htm` files.
- Added configurable pipe name setting for Angular.
- Fixed OpenAI auto-translation capitalization issues.
- Updated changelog for all new enhancements and fixes.